### PR TITLE
Upgrade libs to latest (without Renovate 🤔)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,12 +32,12 @@ repositories {
 }
 
 dependencies {
-  testImplementation("org.junit.jupiter", "junit-jupiter-api", "5.7.0")
-  testImplementation("org.junit.jupiter", "junit-jupiter-params", "5.7.0")
-  testImplementation("org.junit.jupiter", "junit-jupiter-engine", "5.7.0")
-  testImplementation("org.assertj", "assertj-core", "3.18.1")
-  testImplementation("org.mockito", "mockito-core", "3.6.28")
-  testImplementation("net.jqwik", "jqwik", "1.3.10")
+  testImplementation("org.junit.jupiter", "junit-jupiter-api", "5.7.2")
+  testImplementation("org.junit.jupiter", "junit-jupiter-params", "5.7.2")
+  testImplementation("org.junit.jupiter", "junit-jupiter-engine", "5.7.2")
+  testImplementation("org.assertj", "assertj-core", "3.20.2")
+  testImplementation("org.mockito", "mockito-core", "3.12.1")
+  testImplementation("net.jqwik", "jqwik", "1.5.4")
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
I just "nuked" the Renovate configuration but new PRs are not
getting created, so I upgrade libs this way:

  ./gradlew useLatestVersions