### PR TITLE
Use a single JUnit dependency (jupiter) 🧹

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,9 +33,7 @@ repositories {
 }
 
 dependencies {
-  testImplementation("org.junit.jupiter", "junit-jupiter-api", "5.8.2")
-  testImplementation("org.junit.jupiter", "junit-jupiter-params", "5.8.2")
-  testImplementation("org.junit.jupiter", "junit-jupiter-engine", "5.8.2")
+  testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
   testImplementation("org.assertj", "assertj-core", "3.23.1")
   testImplementation("org.mockito", "mockito-core", "4.6.1")
   testImplementation("net.jqwik", "jqwik", "1.6.5")


### PR DESCRIPTION
https://junit.org/junit5/docs/current/user-guide/#dependency-metadata-junit-jupiter