### PR TITLE
Fix #163: use latest wrapper-validation GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
           java-version: '23'
           distribution: 'zulu'
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6
+        uses: gradle/actions/wrapper-validation@v4
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
Use official Gradle GitHub wrolkflow:
https://github.com/gradle/actions/tree/main/wrapper-validation

Instead of unmaintained one:
https://github.com/gradle/wrapper-validation-action?tab=readme-ov-file

It should fix issues like:
https://github.com/gradle/wrapper-validation-action/issues/33
https://github.com/gradle/wrapper-validation-action/issues/40
