### PR TITLE
Use Java 25 ☕️

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '24'
-          distribution: 'zulu'
+          java-version: "25-ea"
+          distribution: "zulu"
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4
       - name: Build with Gradle

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A basic Java setup for [code katas](http://wiki.c2.com/?CodeKata).
 
 Pre-requisites:
 
-- Java Development Kit 24 minimum ([SDKMAN!](https://sdkman.io/) can be used for JDK installation)
+- Java Development Kit 25 minimum ([SDKMAN!](https://sdkman.io/) can be used for JDK installation)
 - Integrated Development Environment compatible with this JDK version (for instance, [IntelliJ IDEA](https://www.jetbrains.com/idea/))
 
 Either use your favorite IDE with [`Gradle`](https://gradle.org/) integration (for instance, [`IntelliJ IDEA`](https://www.jetbrains.com/idea/)) or run:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion.set(JavaLanguageVersion.of(24))
+    languageVersion.set(JavaLanguageVersion.of(25))
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-rc-4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Java 25 is GA today! 🎉
Cf. https://openjdk.org/projects/jdk/25/:

	2025/09/16		General Availability

Upgrade Gradle to 9.1.0-rc-4 for Java 25 compatibility.
https://docs.gradle.org/9.1.0-rc-4/release-notes.html